### PR TITLE
Update .gitignore to include additional Gradle-related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,25 @@ logs/
 /nbdist/
 /.nb-gradle/
 /build/
+# Gradle specific
+.gradle/
+**/build/
+
+# Gradle cache files
+.gradle/buildOutputCleanup/
+.gradle/**/checksums/
+.gradle/**/executionHistory/
+.gradle/**/fileHashes/
+.gradle/**/fileChanges/
+.gradle/**/dependencies-accessors/
+
+# System files
+.gradle/file-system.probe
+
+# Garbage collection properties
+**/*.gc.properties
+
+# Cache and lock files
+**/*.lock
+**/*.bin
+**/*.cache


### PR DESCRIPTION
Expanded .gitignore to exclude Gradle-specific directories, cache files, and other temporary or system-generated files. This ensures a cleaner repository by preventing unwanted Gradle and build artifacts from being tracked.