### PR TITLE
Refactor security configuration and simplify UserDetails logic

### DIFF
--- a/src/main/java/homefinance/common/config/security/SpringSecurityInitializer.java
+++ b/src/main/java/homefinance/common/config/security/SpringSecurityInitializer.java
@@ -1,7 +1,0 @@
-package homefinance.common.config.security;
-
-import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
-
-public class SpringSecurityInitializer extends AbstractSecurityWebApplicationInitializer {
-
-}


### PR DESCRIPTION
Removed `SpringSecurityInitializer` as it's unnecessary. Refactored `UserDetailsServiceImpl` to use Lombok's `@RequiredArgsConstructor` and replaced manual UserDetails construction with `User.builder()`. Streamlined role-to-authority conversion for improved readability and efficiency.